### PR TITLE
QOL changes: get_bits, proptest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[dev-dependencies]
+proptest = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,20 +31,6 @@ enum LoHiRegister {
 }
 
 #[derive(Debug, Clone, Copy)]
-enum AddSubtractOpCode {
-    ADD,
-    SUB
-}
-
-#[derive(Debug, Clone, Copy)]
-struct AddSubtract {
-    op: AddSubtractOpCode,
-    roi: RegisterOrImmediate,
-    src: Register,
-    dest: Register
-}
-
-#[derive(Debug, Clone, Copy)]
 enum MoveCompareAddSubtractImmediateOpCode {
     MOV,
     CMP,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,23 @@ mod thumb {
 use types::*;
 use thumb::msr::MoveShiftedRegister;
 
+// Inclusive range - descending, with 0 on the right, similar to the ARM7 datasheet
+#[macro_export]
+macro_rules! get_bits {
+    ($num:expr, $lhs:literal..$rhs:literal) => {{
+        assert!($lhs >= $rhs);
+        ($num >> $rhs) & ((1 << ($lhs + 1 - $rhs)) - 1)
+    }};
+    ($num:expr, $lhs:literal..) => {{
+        assert!(lhs >= 0);
+        $num & ((1 << $lhs) - 1)
+    }};
+    ($num:expr, ..$rhs:literal) => {{
+        assert!(rhs >= 0);
+        $num >> $rhs
+    }};
+}
+
 #[derive(Debug, Clone, Copy)]
 enum LoHiRegister {
     Lo(Register),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,11 @@ macro_rules! get_bits {
         ($num >> $rhs) & ((1 << ($lhs + 1 - $rhs)) - 1)
     }};
     ($num:expr, $lhs:literal..) => {{
-        assert!(lhs >= 0);
+        assert!($lhs >= 0);
         $num & ((1 << $lhs) - 1)
     }};
     ($num:expr, ..$rhs:literal) => {{
-        assert!(rhs >= 0);
+        assert!($rhs >= 0);
         $num >> $rhs
     }};
 }


### PR DESCRIPTION
Add a macro to get bits without error prone bit logic. (It being a macro will be more useful when we have to handle ARM instructions)

Add proptest - property based testing for fuzzing